### PR TITLE
api_structure -> master 통합 요청

### DIFF
--- a/src/main/java/com/example/spring_project/config/SwaggerConfiguration.java
+++ b/src/main/java/com/example/spring_project/config/SwaggerConfiguration.java
@@ -33,6 +33,6 @@ public class SwaggerConfiguration {
                 .title(title)
                 .version(version)
                 .description("앱 개발시 사용되는 서버 API에 대한 연동 문서입니다")
-                .license("E1psycongr00").licenseUrl("http://daddyprogrammer.org").version("1").build();
+                .license("E1psycongr00").licenseUrl("https://github.com/E1psycongr00/Spring_Project").version("1").build();
     }
 }

--- a/src/main/java/com/example/spring_project/controller/UserController.java
+++ b/src/main/java/com/example/spring_project/controller/UserController.java
@@ -1,14 +1,13 @@
 package com.example.spring_project.controller;
 
-import com.example.spring_project.entity.User;
-import com.example.spring_project.repository.UserRepository;
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.dto.response.Response;
+import com.example.spring_project.service.UserService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @Api(tags ={"1. User"}) // UserController 최상단 타이틀 영역에 표시될 값
 // class 상단에 선언하면 내부의 final 객체에 대하여 Constructor Injection을 수행한다.
@@ -17,20 +16,40 @@ import java.util.List;
 @RestController         // 결과값은 JSON으로 출력 @ResponseBody를 사용 할 필요가 없음.
 @RequestMapping(value = "/v1") // api resource를 버전별로 관리하기 위해서 /v1 이 모두 적용되게 처리함.
 public class UserController {
-    private final UserRepository userRepository; // @RequiredArgsConstructor 에 의해 자동으로 주입됨.
+    private final UserService userService; // @RequiredArgsConstructor 에 의해 자동으로 주입됨.
 
     @ApiOperation(value = "회원조회", notes = "모든 회원을 조회한다.") // 각각의 resource에 설명 제공
     @GetMapping(value = "/users")  // 파라미터에 대한 설명을 보여주기 위해 세팅
-    public List<User> findAllUser() {
-        return userRepository.findAll();
+    public Response<UserDto> findAllUser() {
+        Response<UserDto> response = userService.findAll();
+        return response;
+    }
+
+    @ApiOperation(value = "회원조회", notes = "이름을 통해 모든 회원을 조회한다.")
+    @GetMapping(value = "/users/{name}")
+    public Response<UserDto> findAllUserByUserid(@PathVariable String name) {
+        Response<UserDto> response = userService.findByUserid(name);
+        return response;
     }
 
     @ApiOperation(value="회원 입력", notes = "회원을 입력한다.")
-
     @PostMapping(value = "/user")
-    public User Save(@ApiParam(value = "회원 아이디 정보", required = true) @RequestBody User user) {
-        return userRepository.save(user);
+    public Response<UserDto> saveUser( @RequestBody UserDto userDto) {
+        Response<UserDto> response = userService.insertUser(userDto);
+        return response;
     }
 
+    @ApiOperation(value="회원 수정", notes = "회원을 수정한다.")
+    @PutMapping(value = "/user")
+    public Response<UserDto> updateUser(@RequestBody UserDto userDto) {
+        Response<UserDto> response = userService.updateUser(userDto);
+        return response;
+    }
 
+    @ApiOperation(value="회원 삭제", notes = "회원을 삭제한다.")
+    @PutMapping(value = "/user/{userid}")
+    public Response<UserDto> updateUser(@PathVariable String userid) {
+        Response<UserDto> response = userService.deleteUser(userid);
+        return response;
+    }
 }

--- a/src/main/java/com/example/spring_project/dto/UserDto.java
+++ b/src/main/java/com/example/spring_project/dto/UserDto.java
@@ -1,0 +1,14 @@
+package com.example.spring_project.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserDto {
+
+
+    private String userid;
+    private String name;
+}

--- a/src/main/java/com/example/spring_project/dto/response/CustomHttpStatus.java
+++ b/src/main/java/com/example/spring_project/dto/response/CustomHttpStatus.java
@@ -1,0 +1,37 @@
+package com.example.spring_project.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum CustomHttpStatus {
+
+    // 클라이언트 요청 에러
+    BAD_REQUEST(400, "BAD_REQUEST : 잘못된 요청입니다."),
+    UNAUTHORIZED(401, "UNAUTHORIZED : 인증이 필요한 페이지입니다."),
+    FORBIDDEN(402, "FORBIDDEN : 접근권한이 없습니다."),
+    NOT_FOUND(404, "NOT_FOUND : 요청한 페이지를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(405, "METHOD_NOT_ALLOWED : 허용되지 않은 HTTP 방식입니다."),
+    REQUEST_TIMEOUT(408, "REQUEST_TIMEOUT : 요청 시간이 초과되었습니다."),
+
+    // 서버 에러
+    INTERVAL_SERVER_ERROR(500, "INTERVAL_SERVER_ERROR : 요청 처리 과정에서 내부 서버에 오류가 발생했습니다."),
+    NOT_IMPLEMENTED(501, "NOT_IMPLEMENTED : 요청을 웹 서버에서 처리 할 수 없습니다. 지원하지 않은 방식입니다."),
+    BAD_GATEWAY(502, "BAD_GATEWAY : 게이트웨이 오류입니다"),
+
+    // SuccessCode
+    /**
+     *  code: 200, message: "OK : 요청이 성공적으로 수행되었습니다."
+     */
+    OK(200, "OK : 요청이 성공적으로 수행되었습니다."),
+    CREATED(201, "CREATED : 요청이 성공적으로 수행되고 새로운 리소스가 생성되었습니다."),
+    ACCEPTED(202, "ACCEPTED : 요청이 성공적으로 수행되었지만 응답 할 수 없습니다.")
+    ;
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/example/spring_project/dto/response/Response.java
+++ b/src/main/java/com/example/spring_project/dto/response/Response.java
@@ -1,0 +1,26 @@
+package com.example.spring_project.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Response<T> {
+    @JsonProperty("status")
+    protected CustomHttpStatus code;
+
+    @JsonProperty("detail")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String detail;
+
+    @JsonProperty("data")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+}

--- a/src/main/java/com/example/spring_project/entity/User.java
+++ b/src/main/java/com/example/spring_project/entity/User.java
@@ -16,7 +16,7 @@ public class User {
     private long msrl;
 
     @Column(nullable = false, unique = true, length = 30)
-    private String uid;
+    private String userid;
 
     @Column(nullable = false, length = 100)
     private String name;

--- a/src/main/java/com/example/spring_project/repository/UserRepository.java
+++ b/src/main/java/com/example/spring_project/repository/UserRepository.java
@@ -3,5 +3,12 @@ package com.example.spring_project.repository;
 import com.example.spring_project.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    User findByUserid(String userid);
+    List<User> findAllByName(String name);
+    Long deleteByUserid(String userid);
 }

--- a/src/main/java/com/example/spring_project/service/UserService.java
+++ b/src/main/java/com/example/spring_project/service/UserService.java
@@ -1,0 +1,14 @@
+package com.example.spring_project.service;
+
+
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.dto.response.Response;
+
+public interface UserService {
+    Response findAll();
+    Response findByUserid(String userid);
+    Response insertUser(UserDto userDto);
+    Response updateUser(UserDto userDto);
+    Response deleteUser(String userid);
+
+}

--- a/src/main/java/com/example/spring_project/service/UserServiceImpl.java
+++ b/src/main/java/com/example/spring_project/service/UserServiceImpl.java
@@ -1,0 +1,100 @@
+package com.example.spring_project.service;
+
+
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.dto.response.CustomHttpStatus;
+import com.example.spring_project.dto.response.Response;
+import com.example.spring_project.entity.User;
+import com.example.spring_project.repository.UserRepository;
+import com.example.spring_project.util.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service("userService")
+@Transactional
+@RequiredArgsConstructor  // private final을 이용하면 자동으로 생성자 주입
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+
+    @Override
+    public Response findAll() {
+        List<User> userList = userRepository.findAll();
+        List<UserDto> userDtoList = userList.stream()
+                .map((user) -> UserMapper.mapper(user))
+                .collect(Collectors.toList());
+
+        return Response.<List<UserDto>>builder()
+                    .code(CustomHttpStatus.OK)
+                    .data(userDtoList)
+                    .build();
+    }
+
+    @Override
+    public Response findByUserid(String userid) {
+        User user = userRepository.findByUserid(userid);
+        if (user == null) {
+            return Response.<UserDto>builder()
+                    .code(CustomHttpStatus.ACCEPTED)
+                    .detail("해당 데이터가 없습니다.")
+                    .build();
+        }
+        UserDto userDto = UserMapper.mapper(user);
+
+        return Response.<UserDto>builder()
+                .code(CustomHttpStatus.OK)
+                .data(userDto)
+                .build();
+    }
+
+    @Override
+    public Response insertUser(UserDto userDto) {
+        User user = userRepository.findByUserid(userDto.getUserid());
+        if (user != null) { // 이미 회원이 있는 경우
+            return Response.<UserDto>builder()
+                    .code(CustomHttpStatus.ACCEPTED)
+                    .detail(String.format("%s 회원이 이미 존재합니다. 요청을 받았지만 수행할 수 없습니다.",userDto.getUserid()))
+                    .build();
+        }
+        User user1 = userRepository.save(UserMapper.mapper(userDto));
+        return Response.<UserDto>builder()
+                .code(CustomHttpStatus.OK)
+                .detail(String.format("%s 회원 저장 성공", user1.getUserid()))
+                .build();
+    }
+
+    @Override
+    public Response updateUser(UserDto userDto) {
+        User user = userRepository.findByUserid(userDto.getUserid());
+        if (user == null) { // 회원이 없는 경우
+            return Response.<UserDto>builder()
+                    .code(CustomHttpStatus.ACCEPTED)
+                    .detail(String.format("%s 회원이 존재하지 않습니다. 요청을 받았지만 수행할 수 없습니다.", userDto.getUserid()))
+                    .build();
+        }
+        return Response.<UserDto>builder()
+                .code(CustomHttpStatus.OK)
+                .detail(String.format("%s 회원 저장 성공", user.getUserid()))
+                .build();
+    }
+
+    @Override
+    public Response deleteUser(String userid) {
+        Long l = userRepository.deleteByUserid(userid);
+        if ( l == 0) {
+            return Response.<UserDto>builder()
+                    .code(CustomHttpStatus.ACCEPTED)
+                    .detail("삭제 할 수 없습니다.")
+                    .build();
+        }
+        return Response.<UserDto>builder()
+                .code(CustomHttpStatus.OK)
+                .detail("삭제 성공")
+                .build();
+    }
+}

--- a/src/main/java/com/example/spring_project/util/mapper/UserMapper.java
+++ b/src/main/java/com/example/spring_project/util/mapper/UserMapper.java
@@ -1,0 +1,21 @@
+package com.example.spring_project.util.mapper;
+
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.entity.User;
+
+public class UserMapper {
+
+    public static User mapper(UserDto userDto) {
+        return User.builder()
+                .userid(userDto.getUserid())
+                .name(userDto.getName())
+                .build();
+    }
+
+    public static UserDto mapper(User user) {
+        return UserDto.builder()
+                .userid(user.getUserid())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/test/java/com/example/spring_project/acceptance/ControllerToDatabaseTest.java
+++ b/src/test/java/com/example/spring_project/acceptance/ControllerToDatabaseTest.java
@@ -1,8 +1,9 @@
-package com.example.spring_project.total;
+package com.example.spring_project.acceptance;
 
 
 import com.example.spring_project.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -27,15 +28,16 @@ public class ControllerToDatabaseTest {
     MockMvc mockMvc;             // MVC test
 
     @Test
+    @DisplayName("유저 테스트")
     public void userTest() throws Exception {
 
         //given
         User user1 = User.builder()
-                .uid("marrin1101@naver.com")
+                .userid("marrin1101@naver.com")
                 .name("임현규")
                 .build();
         User user2 = User.builder()
-                .uid("dong@naver.com")
+                .userid("dong@naver.com")
                 .name("임동규")
                 .build();
 
@@ -47,14 +49,13 @@ public class ControllerToDatabaseTest {
         )
         // then
                 .andExpect(status().is(200))
-                .andDo(print());
+                ;
         mockMvc.perform(post("/v1/user")
                         .contentType(MediaType.APPLICATION_JSON)              // json 타입으로 보낼 것을 명시
                         .content(objectMapper.writeValueAsString(user2))       // user 클래스를 Json 으로 변환
                 )
                 // then
-                .andExpect(status().is(200))
-                .andDo(print());
+                .andExpect(status().is(200));
 
         mockMvc.perform(get("/v1/users")
         )

--- a/src/test/java/com/example/spring_project/integration/controller/service/UserServiceToDBTest.java
+++ b/src/test/java/com/example/spring_project/integration/controller/service/UserServiceToDBTest.java
@@ -1,0 +1,158 @@
+package com.example.spring_project.integration.controller.service;
+
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.dto.response.CustomHttpStatus;
+import com.example.spring_project.dto.response.Response;
+import com.example.spring_project.entity.User;
+import com.example.spring_project.repository.UserRepository;
+import com.example.spring_project.service.UserService;
+import com.example.spring_project.service.UserServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+    userService 테스트
+    매 테스트 시작전 하나의 값이 들어간다. 그리고 들어간 데이터를 바탕으로 CRUD를 테스트한다.
+ */
+@DataJpaTest
+@Import({UserServiceImpl.class})
+public class UserServiceToDBTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void beforeTest() {
+        User user = User.builder()
+                        .userid("haha")
+                        .name("hoho")
+                        .build();
+
+        userRepository.save(user);
+    }
+    @Nested
+    @DisplayName("findAll 테스트")
+    class findAllTest {
+
+        @Test
+        @DisplayName("성공시 1을 반환")
+        void successTest() {
+            Response<List<UserDto>> response = userService.findAll();
+            assertThat(response.getData().size()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserid 테스트")
+    class findByUseridTest {
+
+        @Test
+        @DisplayName("데이터가 없는 경우")
+        void failTest() {
+            Response<UserDto> response = userService.findByUserid("hello");
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("데이터가 있는 경우")
+        void successTest() {
+            Response<UserDto> response = userService.findByUserid("haha");
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.OK);
+            assertThat(response.getData().getUserid()).isEqualTo("haha");
+        }
+    }
+
+    @Nested
+    @DisplayName("insertUser 테스트")
+    class insertUserTest {
+
+        @Test
+        @DisplayName("이미 회원이 있어서 등록을 할 수 없는 경우")
+        void failTest() {
+            UserDto userDto = UserDto.builder()
+                    .userid("haha")
+                    .name("hoho")
+                    .build();
+            Response<UserDto> response = userService.insertUser(userDto);
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("등록이 가능한 경우")
+        void successTest() {
+            UserDto userDto = UserDto.builder()
+                    .userid("haha12")
+                    .name("hoho")
+                    .build();
+            Response<UserDto> response = userService.insertUser(userDto);
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.OK);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUser 테스트")
+    class updateUser {
+
+        @Test
+        @DisplayName("회원이 없어서 수정을 못하는 경우")
+        void failTest() {
+            UserDto userDto = UserDto.builder()
+                    .userid("haha12")
+                    .name("hoho")
+                    .build();
+            Response<UserDto> response = userService.updateUser(userDto);
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("수정 가능한 경우")
+        void successTest() {
+            UserDto userDto = UserDto.builder()
+                    .userid("haha")
+                    .name("hoho")
+                    .build();
+            Response<UserDto> response = userService.updateUser(userDto);
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.OK);
+        }
+    }
+
+
+    @Nested
+    @DisplayName("deleteUser 테스트")
+    class deleteUser {
+
+        @Test
+        @DisplayName("회원이 없어서 삭제를 못하는 경우")
+        void failTest() {
+            UserDto userDto = UserDto.builder()
+                    .userid("haha12")
+                    .name("hoho")
+                    .build();
+            Response<UserDto> response = userService.deleteUser("haha12");
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("삭제 가능한 경우")
+        void successTest() {
+            UserDto userDto = UserDto.builder()
+                    .userid("haha")
+                    .name("hoho")
+                    .build();
+            Response<UserDto> response = userService.deleteUser("haha");
+            assertThat(response.getCode()).isEqualTo(CustomHttpStatus.OK);
+        }
+    }
+}

--- a/src/test/java/com/example/spring_project/unit/controller/User/findAllUserByUseridTest.java
+++ b/src/test/java/com/example/spring_project/unit/controller/User/findAllUserByUseridTest.java
@@ -1,0 +1,60 @@
+package com.example.spring_project.unit.controller.User;
+
+
+import com.example.spring_project.controller.UserController;
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.dto.response.CustomHttpStatus;
+import com.example.spring_project.dto.response.Response;
+import com.example.spring_project.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+public class findAllUserByUseridTest {
+    @MockBean
+    UserService userService;
+
+    @Autowired
+    UserController userController;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("findAllUserByUserid 테스트")
+    void successTest() throws Exception {
+        // given
+        UserDto userDto = UserDto.builder()
+                .userid("hello")
+                .name("world")
+                .build();
+        List<UserDto> userDtoList = new ArrayList<>();
+        userDtoList.add(userDto);
+
+
+        Response<List<UserDto>> userListResponse = Response.<List<UserDto>>builder()
+                .code(CustomHttpStatus.OK)
+                        .data(userDtoList)
+                                .build();
+        // when
+        Mockito.doReturn(userListResponse).when(userService).findByUserid("hello");
+
+        // then
+        mockMvc.perform(get("/v1/users/hello"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+    }
+}

--- a/src/test/java/com/example/spring_project/unit/controller/User/findAllUserTest.java
+++ b/src/test/java/com/example/spring_project/unit/controller/User/findAllUserTest.java
@@ -1,0 +1,34 @@
+package com.example.spring_project.unit.controller.User;
+
+
+import com.example.spring_project.controller.UserController;
+import com.example.spring_project.service.UserService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+public class findAllUserTest {
+    @MockBean
+    UserService userService;
+
+    @Autowired
+    UserController userController;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void findAllTest() throws Exception {
+        mockMvc.perform(get("/v1/users"))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/example/spring_project/unit/dto/response/ResponseJsonTest.java
+++ b/src/test/java/com/example/spring_project/unit/dto/response/ResponseJsonTest.java
@@ -1,0 +1,56 @@
+package com.example.spring_project.unit.dto.response;
+
+
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.dto.response.CustomHttpStatus;
+import com.example.spring_project.dto.response.Response;
+import com.example.spring_project.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+public class ResponseJsonTest {
+
+    @Autowired
+    JacksonTester<Response<UserDto>> json;
+
+    @Test
+    void serializeTest() throws IOException {
+        UserDto userDto = UserDto.builder()
+                .userid("hello")
+                .name("world")
+                .build();
+
+        Response<UserDto> response = Response.<UserDto>builder()
+                        .code(CustomHttpStatus.OK)
+                        .data(userDto)
+                        .build();
+//        {"status":{"code":200,"message":"OK : 요청이 성공적으로 수행되었습니다."},"data":{"userid":"hello","name":"world"}}
+        assertThat(json.write(response)).hasJsonPathMapValue("@.status");
+        assertThat(json.write(response)).extractingJsonPathMapValue("@.data")
+                .containsValue("hello");
+
+    }
+
+//    @Test
+//    void deSerializeTest() throws IOException {
+//        UserDto userDto = UserDto.builder()
+//                .userid("hello")
+//                .name("world")
+//                .build();
+//
+//        Response<UserDto> response = Response.<UserDto>builder()
+//                .code(CustomHttpStatus.OK)
+//                .data(userDto)
+//                .build();
+////        {"status":{"code":200,"message":"OK : 요청이 성공적으로 수행되었습니다."},"data":{"userid":"hello","name":"world"}}
+//        String jsonString = "{\"code\":{\"code\":200,\"message\":\"OK : 요청이 성공적으로 수행되었습니다.\"},\"data\":{\"userid\":\"hello\",\"name\":\"world\"}}";
+//        json.parse(jsonString);
+//    }
+}

--- a/src/test/java/com/example/spring_project/unit/repository/User/DeleteByUseridTest.java
+++ b/src/test/java/com/example/spring_project/unit/repository/User/DeleteByUseridTest.java
@@ -1,0 +1,50 @@
+package com.example.spring_project.unit.repository.User;
+
+
+import com.example.spring_project.entity.User;
+import com.example.spring_project.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataJpaTest
+public class DeleteByUseridTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+
+    @Nested
+    @DisplayName("기능 테스트")
+    class DeleteTest {
+
+        @Test
+        @DisplayName("delete 싪패시 0 반환")
+        void failTest() {
+            String userid = "1";
+            Long x = userRepository.deleteByUserid(userid);
+            assertThat(x).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("delete 성공시 1 반환")
+        void successTest() {
+            User user = User.builder()
+                    .userid("1")
+                    .name("hello")
+                    .build();
+
+            userRepository.save(user);
+            Long x = userRepository.deleteByUserid(user.getUserid());
+            assertThat(x).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/example/spring_project/unit/repository/User/FindAllByNameTest.java
+++ b/src/test/java/com/example/spring_project/unit/repository/User/FindAllByNameTest.java
@@ -1,0 +1,68 @@
+package com.example.spring_project.unit.repository.User;
+
+
+import com.example.spring_project.entity.User;
+import com.example.spring_project.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class FindAllByNameTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+
+    @Nested
+    @DisplayName("기능 테스트")
+    class findAllTest {
+
+        @Test
+        @DisplayName("List<User> 타입이 맞는가")
+        void finAllByUseridTest1() {
+            // given
+            User user1 = User.builder()
+                    .userid("hello")
+                    .name("haha1")
+                    .build();
+
+            User user2 = User.builder()
+                    .userid("hello2")
+                    .name("haha1")
+                    .build();
+            userRepository.save(user1);
+            userRepository.save(user2);
+
+            // when
+            List<User> userList = userRepository.findAllByName("haha1");
+
+            // then
+            assertThat(userList.size()).isEqualTo(2);
+
+        }
+
+        @Test
+        @DisplayName("비어 있는 경우 비어있는 리스트 반환")
+        void finAllByUseridTest2() {
+
+
+            // when
+            List<User> userList = userRepository.findAllByName("hoho");
+            assertThat(userList).isInstanceOf(List.class);
+            // then
+            assertThat(userList.size()).isEqualTo(0);
+
+        }
+
+    }
+
+}

--- a/src/test/java/com/example/spring_project/unit/repository/User/FindByUseridTest.java
+++ b/src/test/java/com/example/spring_project/unit/repository/User/FindByUseridTest.java
@@ -1,0 +1,48 @@
+package com.example.spring_project.unit.repository.User;
+
+
+import com.example.spring_project.entity.User;
+import com.example.spring_project.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class FindByUseridTest {
+    @Autowired
+    UserRepository userRepository;
+
+
+    @Nested
+    @DisplayName("리턴 테스트")
+    public class ReturnTypeTest {
+
+        @Test
+        @DisplayName("아무 것도 조회하지 않은 경우 null 반환")
+        public void emptyTest() {
+
+            User user = userRepository.findByUserid("hello");
+            assertThat(user).isEqualTo(null);
+        }
+
+        @Test
+        @DisplayName("존재 할 경우 User 반환")
+        public void UserTest() {
+            // given
+            User user1 = User.builder()
+                    .userid("hello")
+                    .name("haha1")
+                    .build();
+            userRepository.save(user1);
+            User user = userRepository.findByUserid("hello");
+            assertThat(user).isInstanceOf(User.class);
+        }
+    }
+}

--- a/src/test/java/com/example/spring_project/unit/repository/User/SaveTest.java
+++ b/src/test/java/com/example/spring_project/unit/repository/User/SaveTest.java
@@ -1,0 +1,50 @@
+package com.example.spring_project.unit.repository.User;
+
+
+import com.example.spring_project.entity.User;
+import com.example.spring_project.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+public class SaveTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Nested
+    @DisplayName("Save 리턴 테스트")
+    class saveTest {
+
+        @Test
+        @DisplayName("save 성공시 리턴 User")
+        void SuccessTest() {
+            User user = User.builder()
+                    .name("123")
+                    .userid("aa1")
+                    .build();
+
+            User x = userRepository.save(user);
+            assertThat(x.getUserid()).isEqualTo(user.getUserid());
+        }
+
+        @Test
+        @DisplayName("Save 실패시 throw")
+        void FailTest() {
+            // IllegalArgumentException   nested exception 이란?? 통과 못하는 이유가 뭐지??
+//            assertThatThrownBy(() -> userRepository.save(null)).isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> userRepository.save(null))
+                    .isInstanceOf(InvalidDataAccessApiUsageException.class);
+
+        }
+    }
+
+}

--- a/src/test/java/com/example/spring_project/unit/util/mapper/UserMapperTest.java
+++ b/src/test/java/com/example/spring_project/unit/util/mapper/UserMapperTest.java
@@ -1,0 +1,47 @@
+package com.example.spring_project.unit.util.mapper;
+
+
+import com.example.spring_project.dto.UserDto;
+import com.example.spring_project.entity.User;
+import com.example.spring_project.util.mapper.UserMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserMapperTest {
+
+    @Nested     // jupiter.api
+    @DisplayName("mapper 기능 테스트")
+    class functional {
+
+        @Test
+        @DisplayName("user -> dto")
+        void mapperFunctionTest1() {
+            UserDto userDto = UserDto.builder()
+                    .userid("hello")
+                    .name("hihi")
+                    .build();
+
+            User user = UserMapper.mapper(userDto);
+            assertThat(user.getName()).isEqualTo(userDto.getName());
+            assertThat(user.getUserid()).isEqualTo(userDto.getUserid());
+        }
+
+        @Test
+        @DisplayName("dto -> user")
+        void mapperFunctionTest2() {
+            User user = User.builder()
+                    .userid("1")
+                    .msrl(10)
+                    .name("hihi")
+                    .build();
+
+            UserDto userDto = UserMapper.mapper(user);
+            assertThat(user.getName()).isEqualTo(userDto.getName());
+            assertThat(user.getUserid()).isEqualTo(userDto.getUserid());
+        }
+    }
+
+}


### PR DESCRIPTION
큰 틀에서 추가된 점과 변경된 점을 적었습니다. 세세한 부분은 커밋을 참고해주세요.

## 추가

- UserRepository CRUD 메서드 추가
- dto -> entity, entity -> dto 기능을 가진 UserMapper 추가
- 응답 Dto 추가


## 변경

before:

-  Swagger 라이센스 주소가 다른 블로그 사이트
-  UserEntity의 인스턴스 변수 uid
-  Controller에 DB조회, 데이터 변환, request 매핑 모두 담당함.

after:

- url을 우리 깃허브 사이트로 수정
- 가독성을 위해 uid -> userid로 수정
- UserService를 이용해 기능을 분리하고 UserController는 요청과 응답만을 처리